### PR TITLE
Bump spring.version from 4.1.1.RELEASE to 5.2.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<url>http://maven.apache.org</url>
 	<properties>
 		<jdk.version>1.7</jdk.version>
-		<spring.version>4.1.1.RELEASE</spring.version>
+		<spring.version>5.2.7.RELEASE</spring.version>
 		<jstl.version>1.2</jstl.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.0.13</logback.version>


### PR DESCRIPTION
Bumps `spring.version` from 4.1.1.RELEASE to 5.2.7.RELEASE.

Updates `spring-core` from 4.1.1.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.1.1.RELEASE...v5.2.7.RELEASE)

Updates `spring-web` from 4.1.1.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.1.1.RELEASE...v5.2.7.RELEASE)

Updates `spring-webmvc` from 4.1.1.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.1.1.RELEASE...v5.2.7.RELEASE)